### PR TITLE
added import m5 to roi_manager

### DIFF
--- a/workloads/roi_manager.py
+++ b/workloads/roi_manager.py
@@ -25,7 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from gem5.simulate.exit_event import ExitEvent
-
+import m5
 
 def handle_workend():
     while True:


### PR DESCRIPTION
Execution failed when m5 was not found. Fixed it by adding `import m5`